### PR TITLE
Fix YAML

### DIFF
--- a/pages/05-usage.md
+++ b/pages/05-usage.md
@@ -49,7 +49,7 @@ will generate you a template called **YYYY-MM-DD-why-i-_3-octopod.md** (YYYY-MM-
 ---
 title: Why I <3 Octopod
 subtitle: A Subtle Subtitle
-episode-cover: "/img/episode-cover0.jpg' # This can be used to provide episode-specific images
+episode-cover: "/img/episode-cover0.jpg" # This can be used to provide episode-specific images
 datum: March 22nd 2016 # this is no longer necessary, but in de or en installations, it is still respected
 layout: post
 author: Uncle Octopod


### PR DESCRIPTION
`episode-cover` needs to be closed with a double quote. With the incorrect quote, the syntax highlighting of the whole block gets borked.

![Broken YAML](https://user-images.githubusercontent.com/251545/46574782-8d5bf680-c96e-11e8-94f2-64a46c5ae2a6.png)
